### PR TITLE
Fix major oopsie

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function compare (a, b) {
   }
   
   for (var i = 0, il = a.length; i < il; ++i) {
-    mismatch |= (a.charCodeAt(i) ^ a.charCodeAt(i));
+    mismatch |= (a.charCodeAt(i) ^ b.charCodeAt(i));
   }
   
   return mismatch === 0;


### PR DESCRIPTION
`compare` was actually comparing `a` with `a`, meaning the check passes for _any_ two strings of the same length.
